### PR TITLE
Add a minimum length prefix to the .createTempFile calls

### DIFF
--- a/src/main/java/org/rauschig/jarchivelib/ArchiverCompressorDecorator.java
+++ b/src/main/java/org/rauschig/jarchivelib/ArchiverCompressorDecorator.java
@@ -50,7 +50,6 @@ class ArchiverCompressorDecorator implements Archiver {
         
         File temp = File.createTempFile("jAL" + destination.getName(), archiver.getFilenameExtension(), destination);
         File destinationArchive = null;
-
         try {
             temp = archiver.create(temp.getName(), temp.getParentFile(), sources);
             destinationArchive = new File(destination, getArchiveFileName(archive));
@@ -68,7 +67,6 @@ class ArchiverCompressorDecorator implements Archiver {
         IOUtils.requireDirectory(destination);
 
         File temp = File.createTempFile("jAL" + archive.getName(), archiver.getFilenameExtension(), destination);
-
         try {
             compressor.decompress(archive, temp);
             archiver.extract(temp, destination);

--- a/src/main/java/org/rauschig/jarchivelib/ArchiverCompressorDecorator.java
+++ b/src/main/java/org/rauschig/jarchivelib/ArchiverCompressorDecorator.java
@@ -47,7 +47,6 @@ class ArchiverCompressorDecorator implements Archiver {
     @Override
     public File create(String archive, File destination, File... sources) throws IOException {
         IOUtils.requireDirectory(destination);
-        
         File temp = File.createTempFile("jAL" + destination.getName(), archiver.getFilenameExtension(), destination);
         File destinationArchive = null;
         try {
@@ -65,7 +64,6 @@ class ArchiverCompressorDecorator implements Archiver {
     @Override
     public void extract(File archive, File destination) throws IOException {
         IOUtils.requireDirectory(destination);
-
         File temp = File.createTempFile("jAL" + archive.getName(), archiver.getFilenameExtension(), destination);
         try {
             compressor.decompress(archive, temp);

--- a/src/main/java/org/rauschig/jarchivelib/ArchiverCompressorDecorator.java
+++ b/src/main/java/org/rauschig/jarchivelib/ArchiverCompressorDecorator.java
@@ -47,8 +47,8 @@ class ArchiverCompressorDecorator implements Archiver {
     @Override
     public File create(String archive, File destination, File... sources) throws IOException {
         IOUtils.requireDirectory(destination);
-
-        File temp = File.createTempFile(destination.getName(), archiver.getFilenameExtension(), destination);
+        
+        File temp = File.createTempFile("jAL" + destination.getName(), archiver.getFilenameExtension(), destination);
         File destinationArchive = null;
 
         try {
@@ -67,7 +67,7 @@ class ArchiverCompressorDecorator implements Archiver {
     public void extract(File archive, File destination) throws IOException {
         IOUtils.requireDirectory(destination);
 
-        File temp = File.createTempFile(archive.getName(), archiver.getFilenameExtension(), destination);
+        File temp = File.createTempFile("jAL" + archive.getName(), archiver.getFilenameExtension(), destination);
 
         try {
             compressor.decompress(archive, temp);


### PR DESCRIPTION
I had an exception thrown from line 51 because the prefix was too small. The prefix must always be at least 3 chars long, and you will sometimes encounter folders with shorter names on linux and windows.