### PR TITLE
Include top-level folder names in the archive for multi-file archives

### DIFF
--- a/src/main/java/org/rauschig/jarchivelib/Archiver.java
+++ b/src/main/java/org/rauschig/jarchivelib/Archiver.java
@@ -28,11 +28,31 @@ import java.io.InputStream;
 public interface Archiver {
 
     /**
-     * Creates an archive from the given source files or directories, and saves it into the given destination.
+     * Creates an archive from the given source file or directory, and saves it into the given destination.
+     * <p/>
+     * If the source is a directory, the archive will contain all the files in that directory, but not the directory
+     * itself.
      * <p/>
      * If the archive parameter has no file extension (e.g. "archive" instead of "archive.zip"), the concrete archiver
      * implementation should append it according to its file format (.zip, .tar, .tar.gz, ...).
      * 
+     * @param archive the name of the archive to create
+     * @param destination the destination directory where to place the created archive
+     * @param source the input file or directory to archive
+     * @return the newly created archive file
+     * @throws IOException propagated I/O errors by {@code java.io}
+     */
+    File create(String archive, File destination, File source) throws IOException;
+
+    /**
+     * Creates an archive from the given source files or directories, and saves it into the given destination.
+     * <p/>
+     * If the source is a directory, the archive will contain all the files in that directory, but not the directory
+     * itself.
+     * <p/>
+     * If the archive parameter has no file extension (e.g. "archive" instead of "archive.zip"), the concrete archiver
+     * implementation should append it according to its file format (.zip, .tar, .tar.gz, ...).
+     *
      * @param archive the name of the archive to create
      * @param destination the destination directory where to place the created archive
      * @param sources the input files or directories to archive

--- a/src/main/java/org/rauschig/jarchivelib/ArchiverCompressorDecorator.java
+++ b/src/main/java/org/rauschig/jarchivelib/ArchiverCompressorDecorator.java
@@ -49,6 +49,11 @@ class ArchiverCompressorDecorator implements Archiver {
     }
 
     @Override
+    public File create(String archive, File destination, File source) throws IOException {
+        return create(archive, destination, IOUtils.filesContainedIn(source));
+    }
+
+    @Override
     public File create(String archive, File destination, File... sources) throws IOException {
         IOUtils.requireDirectory(destination);
 

--- a/src/main/java/org/rauschig/jarchivelib/CommonsArchiver.java
+++ b/src/main/java/org/rauschig/jarchivelib/CommonsArchiver.java
@@ -45,7 +45,13 @@ class CommonsArchiver implements Archiver {
     }
 
     @Override
+    public File create(String archive, File destination, File source) throws IOException {
+        return create(archive, destination, IOUtils.filesContainedIn(source));
+    }
+
+    @Override
     public File create(String archive, File destination, File... sources) throws IOException {
+
         IOUtils.requireDirectory(destination);
 
         File archiveFile = createNewArchiveFile(archive, getFilenameExtension(), destination);
@@ -219,11 +225,7 @@ class CommonsArchiver implements Archiver {
                 throw new FileNotFoundException(source.getPath() + " (Permission denied)");
             }
 
-            if (source.isFile()) {
-                writeToArchive(source.getParentFile(), new File[]{ source }, archive);
-            } else {
-                writeToArchive(source, source.listFiles(), archive);
-            }
+            writeToArchive(source.getParentFile(), new File[]{ source }, archive);
         }
     }
 

--- a/src/main/java/org/rauschig/jarchivelib/IOUtils.java
+++ b/src/main/java/org/rauschig/jarchivelib/IOUtils.java
@@ -139,4 +139,18 @@ public final class IOUtils {
         }
     }
 
+    /**
+     * Given a source File, return its direct descendants if the File is a directory. Otherwise return the File itself.
+     *
+     * @param source File or folder to be examined
+     * @return a File[] array containing the files inside this folder, or a size-1 array containing the file itself.
+     */
+    public static File[] filesContainedIn(File source) {
+        if (source.isDirectory()) {
+            return source.listFiles();
+        } else {
+            return new File[] { source };
+        }
+    }
+
 }

--- a/src/test/java/org/rauschig/jarchivelib/AbstractArchiverTest.java
+++ b/src/test/java/org/rauschig/jarchivelib/AbstractArchiverTest.java
@@ -90,6 +90,19 @@ public abstract class AbstractArchiverTest extends AbstractResourceTest {
     }
 
     @Test
+    public void create_multipleSourceFiles_properlyCreatesArchive() throws Exception {
+        String archiveName = archive.getName();
+
+        File createdArchive = archiver.create(archiveName, ARCHIVE_CREATE_DIR, ARCHIVE_DIR.listFiles());
+
+        assertTrue(createdArchive.exists());
+        assertEquals(archiveName, createdArchive.getName());
+
+        archiver.extract(createdArchive, ARCHIVE_EXTRACT_DIR);
+        assertDirectoryStructureEquals(ARCHIVE_DIR, ARCHIVE_EXTRACT_DIR);
+    }
+
+    @Test
     public void create_recursiveDirectory_withoutFileExtension_properlyCreatesArchive() throws Exception {
         String archiveName = archive.getName();
 


### PR DESCRIPTION
If multiple folders are added to the archive, ensure that the top-level folder name is also
part of the archive (and that the first level is not flattened). 

See [issue 45](https://github.com/thrau/jarchivelib/issues/45) for details.