### PR TITLE
Update commons-compress to 1.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
   </developers>
 
   <properties>
-    <commons.compress.version>1.20</commons.compress.version>
+    <commons.compress.version>1.21</commons.compress.version>
     <xz.version>1.8</xz.version>
     <junit.version>4.13.1</junit.version>
 


### PR DESCRIPTION
To fix CVE-2021-35515, CVE-2021-35516, CVE-2021-35517 and CVE-2021-36090