### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,14 +134,7 @@
       <artifactId>commons-compress</artifactId>
       <version>${commons.compress.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.tukaani</groupId>
-      <artifactId>xz</artifactId>
-      <version>${xz.version}</version>
-      <optional>true</optional>
-    </dependency>
-
-    <!-- test dependencies -->
+    
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
jarchivelib
{groupId='org.tukaani', artifactId='xz'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
